### PR TITLE
New option for the image to take the size of the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,20 @@ Basic usage example
     <img src="https://github.com/malaman/js-image-zoom/blob/master/example/1.jpg?raw=true" />
 </div>
 <script>
-  var options = {
+
+var options1 = {
     width: 400,
     zoomWidth: 500,
     offset: {vertical: 0, horizontal: 10}
-  };
-  new ImageZoom(document.getElementById("img-container"), options);
+};
+
+// If the width and height of the image are not known or to adjust the image to the container of it
+var options2 = {
+    fillContainer: true,
+    offset: {vertical: 0, horizontal: 10}
+};
+
+new ImageZoom(document.getElementById("img-container"), options2);
 
 </script>
 </body>
@@ -54,6 +62,7 @@ Check basic example in browser:
 - **options** (Object) - js-image-zoom options
      * **width** (number) - width of the source image (optional)
      * **height** (number) - height of the source image (optional).
+     * **fillContainer** (boolean) - true/false (optional). To take the size of the container or if the width & height of the image/container are not known
      * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional)
      * **img** (string) - url of the source image. Provided if container does not contain img element as a tag (optional)
      * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth param is provided)

--- a/example/basic.html
+++ b/example/basic.html
@@ -3,19 +3,26 @@
 <head>
     <meta charset="UTF8">
     <title>Title</title>
-    <script src="https://unpkg.com/js-image-zoom@0.4.1/js-image-zoom.js" type="application/javascript"></script>
+    <!-- <script src="https://unpkg.com/js-image-zoom@0.4.1/js-image-zoom.js" type="application/javascript"></script> -->
+    <script src="../package/js-image-zoom.js"></script>
 </head>
 <body>
-    <div id="img-container" style="width: 400px">
+    <div id="img-container" style="width: 500px; height:300px; border: 5px solid red;">
         <img src="1.jpg" />
     <div>
 <script>
-var options = {
+var options1 = {
     width: 400,
     zoomWidth: 500,
     offset: {vertical: 0, horizontal: 10}
 };
-new ImageZoom(document.getElementById("img-container"), options);
+
+// If the width and height of the image are not known or to adjust the image to the container of it
+var options2 = {
+    fillContainer: true,
+    offset: {vertical: 0, horizontal: 10}
+};
+new ImageZoom(document.getElementById("img-container"), options2);
 
 </script>
 </body>

--- a/package/README.md
+++ b/package/README.md
@@ -33,12 +33,20 @@ Basic usage example
         <img src="https://github.com/malaman/js-image-zoom/blob/master/example/1.jpg" />
     <div>
 <script>
-var options = {
+
+var options1 = {
     width: 400,
     zoomWidth: 500,
     offset: {vertical: 0, horizontal: 10}
 };
-new ImageZoom(document.getElementById("img-container"), options);
+
+// If the width and height of the image are not known or to adjust the image to the container of it
+var options2 = {
+    fillContainer: true,
+    offset: {vertical: 0, horizontal: 10}
+};
+
+new ImageZoom(document.getElementById("img-container"), options2);
 
 </script>
 </body>
@@ -55,6 +63,7 @@ Check basic example in browser:
 - **options** (Object) - js-image-zoom options
      * **width** (number) - width of the source image (optional)
      * **height** (number) - height of the source image (optional).
+     * **fillContainer** (boolean) - true/false (optional). To take the size of the container or if the width & height of the image/container are not known
      * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional)
      * **img** (string) - url of the source image. Provided if container does not contain img element as a tag (optional)
      * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth param is provided)

--- a/package/js-image-zoom.js
+++ b/package/js-image-zoom.js
@@ -117,11 +117,11 @@
         function onSourceImgLoad() {
             // use height determined by browser if height is not set in options
             options.height = options.height || data.sourceImg.element.height;
-            data.sourceImg.element.style.height = options.height + 'px';
+            data.sourceImg.element.style.height = options.fillContainer ? '100%': options.height + 'px';
 
             // use width determined by browser if width is not set in options
-            options.width = options.width || data.sourceImg.element.width;
-            data.sourceImg.element.style.width = options.width + 'px';
+            options.width =  options.width || data.sourceImg.element.width;
+            data.sourceImg.element.style.width = options.fillContainer ? '100%': options.width + 'px';
 
             setZoomedImgSize(options, data);
 
@@ -190,8 +190,8 @@
 
             options = options || {};
             container.style.position = 'relative';
-            data.sourceImg.element.style.width = options.width ? options.width + 'px' : 'auto';
-            data.sourceImg.element.style.height = options.height ? options.height + 'px' : 'auto';
+            data.sourceImg.element.style.width = options.fillContainer ? '100%' : option.width ? options.width + 'px' : 'auto';
+            data.sourceImg.element.style.height = options.fillContainer ? '100%' : options.height ? options.height + 'px' : 'auto';
 
             data.zoomLens.element = container.appendChild(lensDiv);
             data.zoomLens.element.style.display = 'none';


### PR DESCRIPTION
Hello
Recently when I was using this library I had a problem in making the image to take the size of the container where the size of the image was not known. 
So I added few lines of code as an extra option that lets the image take the size of the container without having to give the values of width, height, and zoomWidth.

Please have a look at it and let me know if it's fine. 

Thank you