### PR TITLE
Added zoomSize option and fix scroll offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Basic usage example
 <script>
   var options = {
     width: 400,
-    zoomWidth: 500,
+    zoomSize: 500,
     offset: {vertical: 0, horizontal: 10}
   };
   new ImageZoom(document.getElementById("img-container"), options);
@@ -54,9 +54,10 @@ Check basic example in browser:
 - **options** (Object) - js-image-zoom options
      * **width** (number) - width of the source image (optional)
      * **height** (number) - height of the source image (optional).
-     * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional)
+     * **zoomSize** (number) - set equal width and height of the zoomed image. (optional)
+     * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional will be overwritten by zoomSize)
      * **img** (string) - url of the source image. Provided if container does not contain img element as a tag (optional)
-     * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth param is provided)
+     * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth or zoomSize param is provided)
      * **offset** (object) - {vertical: number, horizontal: number}. Zoomed image offset (optional)
      * **zoomContainer** (node) - DOM node reference where zoomedImage will be appended to (default to the container element of image)
      * **zoomStyle** (string) - custom style applied to the zoomed image (i.e. 'opacity: 0.1;background-color: white;')

--- a/__tests__/js-image-zoom-tests.js
+++ b/__tests__/js-image-zoom-tests.js
@@ -13,7 +13,14 @@ describe('js-image-zoom tests', () => {
         expect(setupData.sourceImg.element).toEqual(jasmine.any(HTMLImageElement));
         expect(setupData.zoomedImg.element).toEqual(jasmine.any(HTMLDivElement));
         expect(setupData.zoomLens.element).toEqual(jasmine.any(HTMLDivElement));
+    });
 
+    it('check creation of elements with width, height, zoomSize, img', () => {
+        const imageZoom = new ImageZoom(document.getElementById('container'), {width: 400, height: 250, zoomSize: 500, img: "../1.jpg"});
+        const setupData = imageZoom._getInstanceInfo().setup();
+        expect(setupData.sourceImg.element).toEqual(jasmine.any(HTMLImageElement));
+        expect(setupData.zoomedImg.element).toEqual(jasmine.any(HTMLDivElement));
+        expect(setupData.zoomLens.element).toEqual(jasmine.any(HTMLDivElement));
     });
 
     it('check creation of elements with width, height, zoomWidth, img, offset', () => {
@@ -31,7 +38,8 @@ describe('js-image-zoom tests', () => {
         expect(setupData.zoomedImg.element).toEqual(jasmine.any(HTMLDivElement));
         expect(setupData.zoomLens.element).toEqual(jasmine.any(HTMLDivElement));
     });
-    it('check creation of elements with width, height, zoomWidth, img, scale, offset, style', () => {
+
+    it('check creation of elements with width, height, img, scale, offset, style', () => {
         const imageZoom = new ImageZoom(document.getElementById('container'), {width: 400, height: 250, scale: 1.5, img: "../1.jpg", offset: {vertical: 0, horizontal: 10}, zoomStyle: "opacity:0.1;"});
         const setupData = imageZoom._getInstanceInfo().setup();
         expect(setupData.sourceImg.element).toEqual(jasmine.any(HTMLImageElement));
@@ -85,6 +93,4 @@ describe('js-image-zoom tests', () => {
         expect(JSON.stringify(setupData.sourceImg.element)).toEqual('{}');
         expect(JSON.stringify(setupData.zoomedImg.element)).toEqual('{}');
     });
-
-
 });

--- a/example/basic.html
+++ b/example/basic.html
@@ -12,7 +12,7 @@
 <script>
 var options = {
     width: 400,
-    zoomWidth: 500,
+    zoomSize: 500,
     offset: {vertical: 0, horizontal: 10}
 };
 new ImageZoom(document.getElementById("img-container"), options);

--- a/example/index.html
+++ b/example/index.html
@@ -103,7 +103,7 @@
     var defaultOptions = {
         width: 400,
         height: 250,
-        zoomWidth: 500,
+        zoomSize: 500,
         img: "1.jpg",
         offset: {vertical: 0, horizontal: 10}
     };
@@ -184,7 +184,7 @@
             document.getElementById('container').classList.add('onehundredpercent');
             delete options.width;
             delete options.height;
-            delete options.zoomWidth;
+            delete options.zoomSize;
         } else {
             document.getElementById('container').classList.remove('onehundredpercent');
             resetOptions();

--- a/package/README.md
+++ b/package/README.md
@@ -35,7 +35,7 @@ Basic usage example
 <script>
 var options = {
     width: 400,
-    zoomWidth: 500,
+    zoomSize: 500,
     offset: {vertical: 0, horizontal: 10}
 };
 new ImageZoom(document.getElementById("img-container"), options);
@@ -55,9 +55,10 @@ Check basic example in browser:
 - **options** (Object) - js-image-zoom options
      * **width** (number) - width of the source image (optional)
      * **height** (number) - height of the source image (optional).
-     * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional)
+     * **zoomSize** (number) - set equal width and height of the zoomed image. (optional)
+     * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional will be overwritten by zoomSize)
      * **img** (string) - url of the source image. Provided if container does not contain img element as a tag (optional)
-     * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth param is provided)
+     * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth or zoomSize param is provided)
      * **offset** (object) - {vertical: number, horizontal: number}. Zoomed image offset (optional)
      * **zoomContainer** (node) - DOM node reference where zoomedImage will be appended to (default to the container element of image)
      * **zoomStyle** (string) - custom style applied to the zoomed image (i.e. 'opacity: 0.1;background-color: white;')

--- a/package/js-image-zoom.js
+++ b/package/js-image-zoom.js
@@ -10,6 +10,7 @@
      * @param {Object} options js-image-zoom options (required)
      * **width** (number) - width of the source image (optional)
      * **height** (number) - height of the source image (optional).
+     * **zoomSize** (number) - set equal width and height of the zoomed image. (optional)
      * **zoomWidth** (number) - width of the zoomed image. Zoomed image height equals source image height (optional)
      * **img** (string) - url of the source image. Provided if container does not contain img element as a tag (optional)
      * **scale** (number) - zoom scale. if not provided, scale is calculated as natural image size / image size, provided in params (optional if zoomWidth param is provided)
@@ -105,6 +106,9 @@
             if (options.scale) {
                 data.zoomedImg.element.style.width = options.width * options.scale + 'px';
                 data.zoomedImg.element.style.height = options.height * options.scale + 'px';
+            } else if (options.zoomSize) {
+                data.zoomedImg.element.style.width = options.zoomSize + 'px';
+                data.zoomedImg.element.style.height = options.zoomSize + 'px';
             } else if (options.zoomWidth) {
                 data.zoomedImg.element.style.width = options.zoomWidth + 'px';
                 data.zoomedImg.element.style.height = data.sourceImg.element.style.height;
@@ -148,6 +152,12 @@
             if (options.scale) {
                 data.zoomLens.width = options.width / (data.sourceImg.naturalWidth / (options.width * options.scale));
                 data.zoomLens.height = options.height / (data.sourceImg.naturalHeight / (options.height * options.scale));
+            }
+
+            // else if zoomSize is set
+            else if (options.zoomSize) {
+                data.zoomLens.width = options.zoomSize / scaleX;
+                data.zoomLens.height = options.zoomSize / scaleX;
             }
 
             // else if zoomWidth is set
@@ -231,8 +241,7 @@
                     data.zoomedImg.element.style.left = '0px';
                     break;
 
-                // Right Position
-                default:
+                default: // right position
                     data.zoomedImg.element.style.position = 'absolute';
                     data.zoomedImg.element.style.top = data.zoomedImgOffset.vertical + 'px';
                     data.zoomedImg.element.style.right = data.zoomedImgOffset.horizontal - (data.zoomedImgOffset.horizontal * 2) + 'px';
@@ -240,27 +249,23 @@
                     break;
             }
 
-
             // setup event listeners
             container.addEventListener('mousemove', events, false);
             container.addEventListener('mouseenter', events, false);
             container.addEventListener('mouseleave', events, false);
             data.zoomLens.element.addEventListener('mouseenter', events, false);
             data.zoomLens.element.addEventListener('mouseleave', events, false);
-            window.addEventListener('scroll', events, false);
 
             return data;
         }
 
         function kill() {
-
             // remove event listeners
             container.removeEventListener('mousemove', events, false);
             container.removeEventListener('mouseenter', events, false);
             container.removeEventListener('mouseleave', events, false);
             data.zoomLens.element.removeEventListener('mouseenter', events, false);
             data.zoomLens.element.removeEventListener('mouseleave', events, false);
-            window.removeEventListener('scroll', events, false);
 
             // remove dom nodes
             if (data.zoomLens && data.zoomedImg) {
@@ -287,8 +292,6 @@
                         return this.handleMouseEnter(event);
                     case 'mouseleave':
                         return this.handleMouseLeave(event);
-                    case 'scroll':
-                        return this.handleScroll(event);
                 }
             },
             handleMouseMove: function (event) {
@@ -297,15 +300,19 @@
                 var backgroundTop;
                 var backgroundRight;
                 var backgroundPosition;
+
+                offset = getOffset(data.sourceImg.element);
+
                 if (offset) {
                     offsetX = zoomLensLeft(event.clientX - offset.left);
                     offsetY = zoomLensTop(event.clientY - offset.top);
+
                     backgroundTop = offsetX * scaleX;
                     backgroundRight = offsetY * scaleY;
                     backgroundPosition = '-' + backgroundTop + 'px ' + '-' + backgroundRight + 'px';
+
                     data.zoomedImg.element.style.backgroundPosition = backgroundPosition;
                     data.zoomLens.element.style.cssText += 'top:' + offsetY + 'px;' + 'left:' + offsetX + 'px;display: block;';
-
                 }
             },
             handleMouseEnter: function () {
@@ -317,9 +324,6 @@
                 data.zoomedImg.element.style.display = 'none';
                 data.zoomLens.element.style.display = 'none';
             },
-            handleScroll: function () {
-                offset = getOffset(data.sourceImg.element);
-            }
         };
 
         // Setup/Initialize library


### PR DESCRIPTION
Recently I used your library in one of our ReactJs projects.

What you created is extremely outstanding!

Here I added one new option called **zoomSize** which makes the zoomed image width and height stay the same.

Also as we add this component inside a standard ReactJs scroller container it stops propagate the _window scroll events_ so I fixed it to always get the offset whenever a mouse moves.

Works perfect and you do not need to listen anymore for the window scroll events.