### PR TITLE
Moved the lense movement via transform to make it more performant and fix CLS issue

### DIFF
--- a/package/js-image-zoom.js
+++ b/package/js-image-zoom.js
@@ -304,7 +304,7 @@
                     backgroundRight = offsetY * scaleY;
                     backgroundPosition = '-' + backgroundTop + 'px ' + '-' + backgroundRight + 'px';
                     data.zoomedImg.element.style.backgroundPosition = backgroundPosition;
-                    data.zoomLens.element.style.cssText += 'top:' + offsetY + 'px;' + 'left:' + offsetX + 'px;display: block;';
+                    data.zoomLens.element.style.cssText += 'transform:' + 'translate(' + offsetX + 'px,' + offsetY +'px);display: block;left:0px;top:0px;'
 
                 }
             },


### PR DESCRIPTION
This makes the lense movement via the transform property to make it more performant(https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/). 

We used the below snippet to check layout shift issues 

`let cls = 0;

new PerformanceObserver((entryList) => {
 for (const entry of entryList.getEntries()) {
   if (!entry.hadRecentInput) {
     cls += entry.value;
     console.log('Current CLS value:', cls, entry);
   }
 }
}).observe({type: 'layout-shift', buffered: true});
` 
We notice that CLS entries are being recorded in browser console when mouse is moves on top of image but after changing it to transform(suggested in https://bugs.chromium.org/p/chromium/issues/detail?id=1161025#c6) there are no CLS entries reported.